### PR TITLE
Allow multiple sass files configuration

### DIFF
--- a/customTypings.d.ts
+++ b/customTypings.d.ts
@@ -9,4 +9,5 @@ declare module "cssnano"
 declare module "postcss"
 declare module "stylelint"
 declare module "node-delete"
-declare module "wait-for-change";
+declare module "wait-for-change"
+declare module "sass-graph"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-template-libs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A collection of utilities which are used by the ng2-templates.",
   "author": {
     "name": "Sven Reglitzki",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "phantomjs-prebuilt": "^2.1.13",
     "postcss": "^5.2.6",
     "rimraf": "^2.5.4",
+    "sass-graph": "^2.1.2",
     "stylelint": "^7.6.0",
     "tslint": "^4.0.2",
     "typescript": "^2.0.10",

--- a/spec/fixtures/a.entry.scss
+++ b/spec/fixtures/a.entry.scss
@@ -1,0 +1,5 @@
+@import "b";
+
+a {
+  content: "version 1";
+}

--- a/spec/fixtures/b.scss
+++ b/spec/fixtures/b.scss
@@ -1,0 +1,5 @@
+@import "c";
+
+b {
+  content: "version 1";
+}

--- a/spec/fixtures/c.scss
+++ b/spec/fixtures/c.scss
@@ -1,0 +1,3 @@
+c {
+  content: "version 1";
+}

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -12,28 +12,36 @@ export class Assets extends EventEmitter {
   }
 
   clean() {
-    del(this.config.clean)
-      .then(() => {
-          this.logger.debug("Clean complete.");
-          this.emit("clean");
-        },
-        e => {
-          this.logger.error("Error during cleaning", e);
-          this.emit("error", e);
-        });
+    if (this.config.clean) {
+      del(this.config.clean)
+        .then(() => {
+            this.logger.debug("Clean complete.");
+            this.emit("clean");
+          },
+          e => {
+            this.logger.error("Error during cleaning", e);
+            this.emit("error", e);
+          });
+    } else {
+      setTimeout(() => this.emit("clean"));
+    }
     return this;
   }
 
   copy() {
-    copy(this.config.copy)
-      .then(() => {
-          this.logger.debug("Copy complete.");
-          this.emit("copy");
-        },
-        e => {
-          this.logger.error("Error during copying", e);
-          this.emit("error", e);
-        });
+    if (this.config.copy) {
+      copy(this.config.copy)
+        .then(() => {
+            this.logger.debug("Copy complete.");
+            this.emit("copy");
+          },
+          e => {
+            this.logger.error("Error during copying", e);
+            this.emit("error", e);
+          });
+    } else {
+      setTimeout(() => this.emit("copy"));
+    }
     return this;
   }
 

--- a/src/bin/compile-styles.ts
+++ b/src/bin/compile-styles.ts
@@ -12,7 +12,7 @@ interface Params extends StylesCompileConfig {
 program
   .usage("[options] <entry>")
   .option("-o, --output <file>", "The output file")
-  .option("-w, --watch-pattern <glob>", "Watch the styles")
+  .option("-w, --watch", "Watch the styles")
   .option("-d, --dev", "Use the dev configuration")
   .parse(process.argv);
 
@@ -22,7 +22,7 @@ params.entry = program.args[0] || defaults.entry;
 
 const compiler = new StyleCompiler(Object.assign({}, defaults, params));
 
-if (!params.watchPattern) {
+if (!params.watch) {
   compiler.on("error", () => process.exit(1));
 }
 

--- a/src/bin/compile-styles.ts
+++ b/src/bin/compile-styles.ts
@@ -11,13 +11,15 @@ interface Params extends StylesCompileConfig {
 
 program
   .usage("[options] <entry>")
-  .option("-o, --output <file>", "The output file")
+  .option("-o, --output <file>", "The output file. Alternatively the outDir option can be used when compiling multiple entries.")
+  .option("-u, --out-dir <directory>", "The output directory. Should be used with multiple entries.")
+  .option("-c, --cwd <direcctory>", "The directory that the entries are relative to. Only makes sense with specified outDir.")
   .option("-w, --watch", "Watch the styles")
   .option("-d, --dev", "Use the dev configuration")
   .parse(process.argv);
 
 const params = program as any as Params;
-const defaults = params.dev ? config.styles.dev : config.styles.dist;
+const defaults = params.dev ? config.styles.dev[0] : config.styles.dist[0];
 params.entry = program.args[0] || defaults.entry;
 
 const compiler = new StyleCompiler(Object.assign({}, defaults, params));

--- a/src/bin/dev.ts
+++ b/src/bin/dev.ts
@@ -21,7 +21,8 @@ assets
     assets.copy();
     new ScriptLinter(config.scripts.lint.dev).on("error", onError).start();
     new StyleLinter(config.styles.lint.dev).on("error", onError).start();
-    new StyleCompiler(config.styles.dev).on("error", onError).start();
+    config.styles.dev.forEach(styleConfig =>
+      new StyleCompiler(styleConfig).on("error", onError).start());
     new TranslationCompiler(config.translations.dev).on("error", onError).start();
     new TestRunner(config.scripts.test.dev).on("error", onError).start();
   });

--- a/src/bin/dist.ts
+++ b/src/bin/dist.ts
@@ -17,6 +17,7 @@ assets
     assets.copy();
     new ScriptLinter(config.scripts.lint.dist).on("error", onError).start();
     new StyleLinter(config.styles.lint.dist).on("error", onError).start();
-    new StyleCompiler(config.styles.dist).on("error", onError).start();
+    config.styles.dist.forEach(styleConfig =>
+      new StyleCompiler(styleConfig).on("error", onError).start());
     new TranslationCompiler(config.translations.dist).on("error", onError).start();
   });

--- a/src/config/config.defaults.ts
+++ b/src/config/config.defaults.ts
@@ -28,22 +28,21 @@ const karmaConfig = (bundleFile: string, watch: boolean) => ({
   singleRun: !watch
 } as KarmaConfig);
 
-const stylesConfig = (dev: boolean) => ({
-  entry: "src/styles/main.scss",
-  output: dev ? ".tmp/main.css" : "dist/main.css",
-  minify: !dev,
+const styles = (dev: boolean) => ({
   watch: dev,
   sass: {
     includePaths: ["node_modules"]
   },
-  postcss: dev ?
-    [
-      ["autoprefixer", {browsers: ["last 2 versions"]}]
-    ] :
-    [
-      ["autoprefixer", {browsers: ["last 2 versions"]}],
-      ["cssnano", {zindex: false}]
-    ]
+  postcss: [
+    ["autoprefixer", {browsers: ["last 2 versions"]}] as any[]
+  ].concat(dev ? [] : [
+    ["cssnano", {zindex: false}]
+  ])
+});
+
+const globalStylesConfig = (dev: boolean) => Object.assign({}, styles(dev), {
+  entry: "src/styles/main.scss",
+  output: dev ? ".tmp/main.css" : "dist/main.css",
 } as StylesCompileConfig);
 
 const defaults: TemplateConfig = {
@@ -106,8 +105,8 @@ const defaults: TemplateConfig = {
     }
   },
   styles: {
-    dev: stylesConfig(true),
-    dist: stylesConfig(false),
+    dev: [globalStylesConfig(true)],
+    dist: [globalStylesConfig(false)],
     lint: {
       dev: {
         files: "src/**/*.scss",

--- a/src/config/config.defaults.ts
+++ b/src/config/config.defaults.ts
@@ -32,7 +32,7 @@ const stylesConfig = (dev: boolean) => ({
   entry: "src/styles/main.scss",
   output: dev ? ".tmp/main.css" : "dist/main.css",
   minify: !dev,
-  watchPattern: dev && "src/styles/**/*.scss",
+  watch: dev,
   sass: {
     includePaths: ["node_modules"]
   },

--- a/src/config/config.interface.ts
+++ b/src/config/config.interface.ts
@@ -25,10 +25,41 @@ export interface SassConfig {
 }
 
 export interface StylesCompileConfig {
-  entry?: string;
+  /**
+   * One or multiple entry files. Also globbing patterns can be used.
+   */
+  entry?: string | string[];
+  /**
+   * Use this option to change the directory that the entry file(s) are relative to.
+   * This will have an influence on the directory structure if used together with the outDir option:
+   * When the output is written, the entry files directory will be flattened down to the cwd.
+   */
+  cwd?: string;
+  /**
+   * Use this option for one single output file.
+   * This is an alternative to the outDir option.
+   */
   output?: string;
-  minify?: boolean;
+  /**
+   * Use this option for multiple entry files.
+   * This is an alternative to the output option.
+   */
+  outDir?: string;
+  /**
+   * If set to true, the sass files will be watched and recompiled.
+   */
   watch?: boolean;
+  /**
+   * If set to true, the output will be wrapped in a module which exports the css as default.
+   */
+  asESModule?: boolean;
+  /**
+   * Whether to output source map files.
+   */
+  sourceMaps?: boolean;
+  /**
+   * The configuration for node-sass.
+   */
   sass?: SassConfig;
   /**
    * A postcss configuration looks like this:
@@ -56,8 +87,8 @@ export interface CopyConfig {
 }
 
 export interface AssetsConfig {
-  copy?: CopyConfig | CopyConfig[];
-  clean?: string | string[];
+  copy?: CopyConfig | CopyConfig[] | false;
+  clean?: string | string[] | false;
 }
 
 export interface ScriptsConfig {
@@ -93,8 +124,8 @@ export interface TemplateConfig {
     };
   };
   styles?: {
-    dev?: StylesCompileConfig;
-    dist?: StylesCompileConfig;
+    dev?: StylesCompileConfig[];
+    dist?: StylesCompileConfig[];
     lint?: {
       dev?: StylesLintingConfig;
       dist?: StylesLintingConfig;

--- a/src/config/config.interface.ts
+++ b/src/config/config.interface.ts
@@ -28,7 +28,7 @@ export interface StylesCompileConfig {
   entry?: string;
   output?: string;
   minify?: boolean;
-  watchPattern?: string | string[];
+  watch?: boolean;
   sass?: SassConfig;
   /**
    * A postcss configuration looks like this:

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,7 +19,8 @@ function getConfig() {
   });
   const emitResult = program.emit(undefined, (fileName: string, data: string) => {
     config = runInNewContext(data, {
-      exports: {}
+      exports: {},
+      require
     }, {
       filename: "config.ts"
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {TemplateConfig} from "./config/config.interface";
+export * from "./config/config.interface";
 export {default as config} from "./config/config";
 export {getLogger} from "log4js";

--- a/src/styles.spec.ts
+++ b/src/styles.spec.ts
@@ -1,0 +1,171 @@
+import {beforeAll, afterAll, it, await as waitFor} from "jasmine-await";
+import * as log4js from "log4js";
+import {copy, readFile, writeFile, del} from "./utils";
+import {StyleCompiler} from "./styles";
+import {StylesCompileConfig} from "./config/config.interface";
+
+describe("StyleCompiler", () => {
+
+  let compiler: StyleCompiler;
+
+  const compiled = () =>
+    new Promise((resolve, reject) =>
+      compiler
+        .once("success", resolve)
+        .once("error", reject));
+
+  const createAndWaitForFirstRun = (options: StylesCompileConfig) => {
+    compiler = new StyleCompiler(options).start();
+    waitFor(Promise.all([compiled()].concat(options.watch ? [new Promise(resolve => compiler.once("watch", resolve))] : [])));
+  };
+
+  const outputWithoutSpaces = (file: string) => {
+    return waitFor(readFile(`.tmp/compiled/${file}`)).replace(/\s/g, "");
+  };
+
+  const stopCompiler = () => compiler.stop();
+
+  const writeVersion = (file: string, version: number) => {
+    const content = waitFor(readFile(`.tmp/fixtures/${file}`))
+      .replace(/(version\s*)\d+/, `$1${version.toString()}`);
+    waitFor(Promise.all([compiled(), writeFile(`.tmp/fixtures/${file}`, content)]));
+  };
+
+  beforeAll(() => {
+    log4js.getLogger("compile-styles").setLevel(log4js.levels.OFF);
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+  });
+
+  afterAll(() => {
+    log4js.getLogger("compile-styles").setLevel(log4js.levels.TRACE);
+    waitFor(del(".tmp"));
+  });
+
+  describe("start()", () => {
+
+    describe("single entry", () => {
+
+      beforeAll(() => waitFor(copy({cwd: "spec", src: "fixtures/**/*.scss", dest: ".tmp"})));
+
+      describe("without watch", () => {
+
+        it("should initially compile the styles", () => {
+          createAndWaitForFirstRun({
+            entry: ".tmp/fixtures/a.entry.scss",
+            output: ".tmp/compiled/test.css"
+          });
+
+          const output = outputWithoutSpaces("test.css");
+          expect(output).toMatch('a{content:"version1";}');
+          expect(output).toMatch('b{content:"version1";}');
+          expect(output).toMatch('c{content:"version1";}');
+        });
+      });
+
+      describe("with watch", () => {
+
+        beforeAll(() => {
+          createAndWaitForFirstRun({
+            entry: ".tmp/fixtures/a.entry.scss",
+            output: ".tmp/compiled/test.css",
+            watch: true
+          });
+        });
+
+        afterAll(stopCompiler);
+
+        it("should initially compile the styles", () => {
+          const output = outputWithoutSpaces("test.css");
+          expect(output).toMatch('a{content:"version1";}');
+          expect(output).toMatch('b{content:"version1";}');
+          expect(output).toMatch('c{content:"version1";}');
+        });
+
+        it("should compile on entry file change", () => {
+          writeVersion("a.entry.scss", 2);
+
+          expect(outputWithoutSpaces("test.css")).toMatch('a{content:"version2";}');
+        });
+
+        it("should compile on direct dependency change", () => {
+          writeVersion("b.scss", 2);
+
+          expect(outputWithoutSpaces("test.css")).toMatch('b{content:"version2";}');
+        });
+
+        it("should compile on direct dependency change", () => {
+          writeVersion("c.scss", 2);
+
+          expect(outputWithoutSpaces("test.css")).toMatch('c{content:"version2";}');
+        });
+      });
+    });
+
+    describe("multiple entries", () => {
+
+      beforeAll(() => waitFor(copy({cwd: "spec", src: "fixtures/**/*.scss", dest: ".tmp"})));
+
+      describe("without watch", () => {
+
+        it("should initially compile the styles", () => {
+          createAndWaitForFirstRun({
+            entry: "*.entry.scss",
+            outDir: ".tmp/compiled",
+            cwd: ".tmp/fixtures"
+          });
+
+          const output = outputWithoutSpaces("a.entry.css");
+          expect(output).toMatch('a{content:"version1";}');
+          expect(output).toMatch('b{content:"version1";}');
+          expect(output).toMatch('c{content:"version1";}');
+        });
+      });
+
+      describe("with watch", () => {
+
+        beforeAll(() => {
+          createAndWaitForFirstRun({
+            entry: "*.entry.scss",
+            outDir: ".tmp/compiled",
+            cwd: ".tmp/fixtures",
+            watch: true
+          });
+        });
+
+        afterAll(stopCompiler);
+
+        it("should initially compile the styles", () => {
+          const output = outputWithoutSpaces("a.entry.css");
+          expect(output).toMatch('a{content:"version1";}');
+          expect(output).toMatch('b{content:"version1";}');
+          expect(output).toMatch('c{content:"version1";}');
+        });
+
+        it("should compile on entry file change", () => {
+          writeVersion("a.entry.scss", 2);
+
+          expect(outputWithoutSpaces("a.entry.css")).toMatch('a{content:"version2";}');
+        });
+
+        it("should compile on direct dependency change", () => {
+          writeVersion("b.scss", 2);
+
+          expect(outputWithoutSpaces("a.entry.css")).toMatch('b{content:"version2";}');
+        });
+
+        it("should compile on direct dependency change", () => {
+          writeVersion("c.scss", 2);
+
+          expect(outputWithoutSpaces("a.entry.css")).toMatch('c{content:"version2";}');
+        });
+
+        it("should compile entry file on add", () => {
+          writeFile(".tmp/fixtures/d.entry.scss", 'd{content:"version1";}');
+          waitFor(compiled());
+
+          expect(outputWithoutSpaces("d.entry.css")).toMatch('d{content:"version1";}');
+        });
+      });
+    });
+  });
+});

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -8,63 +8,92 @@ import * as postcss from "postcss";
 import * as styleLint from "stylelint";
 import * as log4js from "log4js";
 import * as sassGraph from "sass-graph";
+import * as chokidar from "chokidar";
 
 import {StylesCompileConfig, StylesLintingConfig} from "./config/config.interface";
 import utils from "./utils";
 
 export class StyleCompiler extends EventEmitter {
 
-  private logger = log4js.getLogger("global-styles");
+  private logger: log4js.Logger = log4js.getLogger("compile-styles");
+  private watcher: fs.FSWatcher;
+  private entryWatchers: {[file: string]: fs.FSWatcher} = {};
+  private relativePath: string = this.config.cwd || "";
 
   constructor(private config: StylesCompileConfig) {
     super();
   }
 
   start() {
-    this.run();
     if (this.config.watch) {
-      let filesToWatch = this.getFilesToWatch();
-      const watcher = utils.watch(filesToWatch, () => {
-        this.run();
-        const newFilesToWatch = this.getFilesToWatch(entry);
-        const addedDeps = _.without(newFilesToWatch, ...filesToWatch);
-        const removedDeps = _.without(filesToWatch, ...newFilesToWatch);
-        _.each(addedDeps, file => watcher.add(file));
-        _.each(removedDeps, file => watcher.unwatch(file));
-        filesToWatch = newFilesToWatch;
-      });
+      this.watcher = chokidar.watch(this.config.entry as string[], _.pick(this.config, ["cwd"]))
+        .on("unlink", (entry: string) => {
+          this.entryWatchers[entry].close();
+          this.emit("unwatch", entry);
+        })
+        .on("add", (entry: string) => {
+          this.watchForChanges(entry);
+          this.run(entry);
+          this.emit("watch", entry);
+        });
+    } else {
+      this.run(this.config.entry);
     }
 
     return this;
   }
 
-  getFilesToWatch() {
-    return _.keys(sassGraph.parseFile(this.config.entry, {
+  stop() {
+    if (this.watcher) {
+      this.watcher.close();
+    }
+    _.each(this.entryWatchers, watcher => watcher.close());
+  }
+
+  private watchForChanges(entry: string) {
+    let filesToWatch = this.getFilesToWatch(entry);
+    const watcher = utils.watch(filesToWatch, () => {
+      this.run(entry);
+      const newFilesToWatch = this.getFilesToWatch(entry);
+      const addedDeps = _.without(newFilesToWatch, ...filesToWatch);
+      const removedDeps = _.without(filesToWatch, ...newFilesToWatch);
+      _.each(addedDeps, file => watcher.add(file));
+      _.each(removedDeps, file => watcher.unwatch(file));
+      filesToWatch = newFilesToWatch;
+    }, _.pick(this.config, ["cwd"]));
+    this.entryWatchers[entry] = watcher;
+  }
+
+  private getFilesToWatch(entry: string) {
+    return _.keys(sassGraph.parseFile(path.join(this.relativePath, entry), {
       extensions: ["sass", "scss", "css"]
     }).index);
   }
 
-  run() {
-    this.compile()
-      .then(
-        () => {
-          this.logger.debug(`Global styles written to ${this.config.output}`);
-          this.emit("success");
-        },
-        (err) => {
-          this.logger.error("Error processing global styles:", err);
-          this.emit("error", err);
+  private run(entries: string | string[]) {
+    utils.getFiles(entries, _.pick(this.config, ["cwd"]))
+      .then(entryFiles => {
+        entryFiles.forEach(entryFile => {
+          this.compile(entryFile)
+            .then(
+              () => this.emit("success"),
+              (err) => {
+                this.logger.error("Error processing styles:", err);
+                this.emit("error", err);
+              });
         });
+      });
 
     return this;
   }
 
   private preprocess(file: string) {
+    const sourceMapOptions = this.config.sourceMaps ? {
+      sourceMapEmbed: true,
+      sourceMapContents: true,
+    } : {};
     return new Promise((resolve, reject) =>
-      sass.render(_.assign({file: file}, this.config.sass, {
-        sourceMapEmbed: true,
-        sourceMapContents: true,
-      }), (error, result) => {
+      sass.render(_.assign({file: file}, this.config.sass, sourceMapOptions), (error, result) => {
         if (error) {
           error.message = `${error.line}:${error.column} ${error.message}`;
           reject(error);
@@ -74,7 +103,7 @@ export class StyleCompiler extends EventEmitter {
       }));
   }
 
-  private postprocess(processed: any) {
+  private postprocess(output: string, processed: any) {
     return new Promise((resolve, reject) => {
       postcss((this.config.postcss || []).map(([pluginName, pluginConfig]) => {
         const plugin = require(pluginName);
@@ -83,7 +112,10 @@ export class StyleCompiler extends EventEmitter {
         }
         return plugin;
       }))
-        .process(processed.css, {map: {inline: false}, to: this.config.output})
+        .process(processed.css, {
+          map: this.config.sourceMaps && {inline: false},
+          to: output
+        })
         .then(
           (result: any) => resolve(result),
           reject
@@ -91,17 +123,21 @@ export class StyleCompiler extends EventEmitter {
     });
   }
 
-  private write(processed: any) {
-    return Promise.all([
-      utils.writeFile(this.config.output, processed.css),
-      utils.writeFile(`${this.config.output}.map`, processed.map)
-    ]);
+  private write(output: string, processed: any) {
+    const content = this.config.asESModule ? `export default \`${processed.css}\`;` : processed.css;
+    return Promise.all(
+      [utils.writeFile(output, content)]
+        .concat(this.config.sourceMaps ? [utils.writeFile(`${output}.map`, processed.map)] : []));
   }
 
-  private compile() {
-    return this.preprocess(this.config.entry)
-      .then((processed) => this.postprocess(processed))
-      .then((processed) => this.write(processed));
+  private compile(entry: string) {
+    const outputFile = this.config.output
+      || path.join(this.config.outDir, entry.replace(/\.(s[ac]ss)$/, this.config.asESModule ? ".$1.js" : ".css"));
+    const entryFile = path.join(this.relativePath, entry);
+    return this.preprocess(entryFile)
+      .then((processed) => this.postprocess(outputFile, processed))
+      .then((processed) => this.write(outputFile, processed))
+      .then(() => this.logger.debug(`Compiled ${entryFile} to ${outputFile}`));
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,10 +34,10 @@ export function writeFile(dest: string, content: string, options: any = {}) {
       err ? reject(err) : fs.writeFile(dest, content, options, e =>
         e ? reject(e) : resolve(dest))));
 }
-export function watch(pattern: string,
+export function watch(pattern: string | string[],
                       onChange: (files: string[]) => any,
                       opts: any = {debounce: 100, events: ["change"]}) {
-  const watcher = chokidar.watch(pattern, opts);
+  const watcher = chokidar.watch(pattern as string[], opts);
   const files: string[] = [];
   const debouncedCallback = _.debounce(() => {
     onChange(files);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/commander@^2.3.30":
+"@types/commander@^2.3.31":
   version "2.3.31"
   resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.3.31.tgz#c60e5517091f9e2200a5e2063a830eddac4a7036"
   dependencies:
@@ -56,7 +56,7 @@
     "@types/log4js" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.37":
+"@types/lodash@^4.14.41":
   version "4.14.41"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.41.tgz#6f65b0453778d482dc11fc11601c5c7bc98f04d0"
 
@@ -78,7 +78,7 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
-"@types/node-sass@^3.10.30":
+"@types/node-sass@^3.10.32":
   version "3.10.32"
   resolved "https://registry.yarnpkg.com/@types/node-sass/-/node-sass-3.10.32.tgz#b296cce7144ffab77b84090caad4f1e4bbea8e09"
   dependencies:
@@ -293,7 +293,7 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-autoprefixer@^6.0.0, autoprefixer@^6.3.1, autoprefixer@^6.5.1:
+autoprefixer@^6.0.0, autoprefixer@^6.3.1, autoprefixer@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.5.3.tgz#2d853af66d04449fcf50db3066279ab54c3e4b01"
   dependencies:
@@ -779,7 +779,7 @@ css-tokenize@^1.0.1:
     inherits "^2.0.1"
     readable-stream "^1.0.33"
 
-cssnano@^3.7.7:
+cssnano@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.8.1.tgz#008a482148ee948cf0af2ee6e44bd97c53f886ec"
   dependencies:
@@ -1973,7 +1973,7 @@ js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
-js-yaml@^3.4.3, js-yaml@^3.6.1:
+js-yaml@^3.4.3, js-yaml@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -2207,7 +2207,7 @@ lodash@^3.8.0, lodash@v3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.5.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
@@ -2472,7 +2472,7 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^3.10.1:
+node-sass@^3.13.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.13.0.tgz#d08b95bdebf40941571bd2c16a9334b980f8924f"
   dependencies:
@@ -2748,7 +2748,7 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
-phantomjs-prebuilt@^2.1.12, phantomjs-prebuilt@^2.1.7:
+phantomjs-prebuilt@^2.1.13, phantomjs-prebuilt@^2.1.7:
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz#66556ad9e965d893ca5a7dc9e763df7e8697f76d"
   dependencies:
@@ -3026,7 +3026,7 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
-postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.8, postcss@^5.2.4, postcss@^5.2.5:
+postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.8, postcss@^5.2.4, postcss@^5.2.5, postcss@^5.2.6:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.6.tgz#a252cd67cd52585035f17e9ad12b35137a7bdd9e"
   dependencies:
@@ -3360,7 +3360,7 @@ rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.4, rimraf@~2.5.1, rimraf@~2.5.4, rimra
   dependencies:
     glob "^7.0.5"
 
-sass-graph@^2.1.1:
+sass-graph, sass-graph@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.1.2.tgz#965104be23e8103cb7e5f710df65935b317da57b"
   dependencies:
@@ -3692,7 +3692,7 @@ stylehacks@^2.3.0:
     text-table "^0.2.0"
     write-file-stdout "0.0.2"
 
-stylelint@^7.5.0:
+stylelint@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.6.0.tgz#ddeb06ccc95f72c119fcde5e85439fb7e9cde4df"
   dependencies:
@@ -3931,7 +3931,7 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.0.0, typescript@^2.0.6:
+typescript@^2.0.0, typescript@^2.0.10:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.1.tgz#41c2b64472f529331b2055c0424862b44ce58d42"
 


### PR DESCRIPTION
This PR provides the capability that
* Mutliple style processing configurations can be added
* Sass processing can optionally be wrapped in ES modules with default export

This way we don't have to rely on [plugin-scss](https://github.com/KevCJones/plugin-scss).

@DorianGrey 